### PR TITLE
Implement pantry domain and shopping session UI

### DIFF
--- a/Itemize/AppShell.xaml
+++ b/Itemize/AppShell.xaml
@@ -9,26 +9,20 @@
     Title="Itemize">
 
     <ShellContent
-        Title="Dashboard"
-        Icon="{StaticResource IconDashboard}"
+        Title="Dispensa"
+        Icon="{StaticResource IconPantry}"
         ContentTemplate="{DataTemplate pages:MainPage}"
-        Route="main" />
+        Route="pantry" />
 
     <ShellContent
-        Title="Projects"
-        Icon="{StaticResource IconProjects}"
-        ContentTemplate="{DataTemplate pages:ProjectListPage}"
-        Route="projects" />
-
-    <ShellContent
-        Title="Manage Meta"
-        Icon="{StaticResource IconMeta}"
-        ContentTemplate="{DataTemplate pages:ManageMetaPage}"
-        Route="manage" />
+        Title="Sessione spesa"
+        Icon="{StaticResource IconShopping}"
+        ContentTemplate="{DataTemplate pages:ShoppingSessionPage}"
+        Route="shopping" />
 
     <Shell.FlyoutFooter>
         <Grid Padding="15">
-            <sf:SfSegmentedControl x:Name="ThemeSegmentedControl" 
+            <sf:SfSegmentedControl x:Name="ThemeSegmentedControl"
                 VerticalOptions="Center" HorizontalOptions="Center" SelectionChanged="SfSegmentedControl_SelectionChanged"
                 SegmentWidth="40" SegmentHeight="40">
                 <sf:SfSegmentedControl.ItemsSource>

--- a/Itemize/GlobalUsings.cs
+++ b/Itemize/GlobalUsings.cs
@@ -1,6 +1,8 @@
 global using Fonts;
-global using Itemize.Data;
+global using Itemize.Models;
+global using Itemize.Models.Pantry;
 global using Itemize.PageModels;
 global using Itemize.Pages;
 global using Itemize.Services;
+global using Itemize.Services.Pantry;
 global using Itemize.Utilities;

--- a/Itemize/MauiProgram.cs
+++ b/Itemize/MauiProgram.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Maui;
+using CommunityToolkit.Maui;
 using Microsoft.Extensions.Logging;
 using Syncfusion.Maui.Toolkit.Hosting;
 
@@ -16,7 +16,7 @@ namespace Itemize
                 .ConfigureMauiHandlers(handlers =>
                 {
 #if IOS || MACCATALYST
-    				handlers.AddHandler<Microsoft.Maui.Controls.CollectionView, Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2>();
+                    handlers.AddHandler<Microsoft.Maui.Controls.CollectionView, Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2>();
 #endif
                 })
                 .ConfigureFonts(fonts =>
@@ -28,22 +28,17 @@ namespace Itemize
                 });
 
 #if DEBUG
-    		builder.Logging.AddDebug();
-    		builder.Services.AddLogging(configure => configure.AddDebug());
+            builder.Logging.AddDebug();
+            builder.Services.AddLogging(configure => configure.AddDebug());
 #endif
 
-            builder.Services.AddSingleton<ProjectRepository>();
-            builder.Services.AddSingleton<TaskRepository>();
-            builder.Services.AddSingleton<CategoryRepository>();
-            builder.Services.AddSingleton<TagRepository>();
-            builder.Services.AddSingleton<SeedDataService>();
-            builder.Services.AddSingleton<ModalErrorHandler>();
+            builder.Services.AddSingleton<InMemoryPantryStore>();
+            builder.Services.AddSingleton<IPantryStore>(sp => sp.GetRequiredService<InMemoryPantryStore>());
+            builder.Services.AddSingleton<IProductCatalog>(sp => sp.GetRequiredService<InMemoryPantryStore>());
+            builder.Services.AddSingleton<RecipeSuggestionService>();
+            builder.Services.AddSingleton<FamilyContext>();
             builder.Services.AddSingleton<MainPageModel>();
-            builder.Services.AddSingleton<ProjectListPageModel>();
-            builder.Services.AddSingleton<ManageMetaPageModel>();
-
-            builder.Services.AddTransientWithShellRoute<ProjectDetailPage, ProjectDetailPageModel>("project");
-            builder.Services.AddTransientWithShellRoute<TaskDetailPage, TaskDetailPageModel>("task");
+            builder.Services.AddSingleton<ShoppingSessionPageModel>();
 
             return builder.Build();
         }

--- a/Itemize/Models/Pantry/Family.cs
+++ b/Itemize/Models/Pantry/Family.cs
@@ -1,0 +1,26 @@
+using Microsoft.Maui.Graphics;
+
+namespace Itemize.Models.Pantry;
+
+public class Family
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public string Name { get; set; } = string.Empty;
+
+    public Color AccentColor { get; set; } = Colors.Orange;
+
+    public List<FamilyMembership> Members { get; set; } = new();
+
+    public Pantry Pantry { get; set; } = new();
+
+    public Family Clone()
+        => new()
+        {
+            Id = Id,
+            Name = Name,
+            AccentColor = AccentColor,
+            Members = Members.Select(m => m.Clone()).ToList(),
+            Pantry = Pantry.Clone(),
+        };
+}

--- a/Itemize/Models/Pantry/FamilyMembership.cs
+++ b/Itemize/Models/Pantry/FamilyMembership.cs
@@ -1,0 +1,16 @@
+namespace Itemize.Models.Pantry;
+
+public class FamilyMembership
+{
+    public Guid UserId { get; set; }
+        = Guid.Empty;
+
+    public FamilyRole Role { get; set; } = FamilyRole.Member;
+
+    public FamilyMembership Clone()
+        => new()
+        {
+            UserId = UserId,
+            Role = Role,
+        };
+}

--- a/Itemize/Models/Pantry/FamilyRole.cs
+++ b/Itemize/Models/Pantry/FamilyRole.cs
@@ -1,0 +1,7 @@
+namespace Itemize.Models.Pantry;
+
+public enum FamilyRole
+{
+    Owner,
+    Member,
+}

--- a/Itemize/Models/Pantry/Pantry.cs
+++ b/Itemize/Models/Pantry/Pantry.cs
@@ -1,0 +1,19 @@
+namespace Itemize.Models.Pantry;
+
+public class Pantry
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid FamilyId { get; set; }
+        = Guid.Empty;
+
+    public List<PantryItem> Items { get; set; } = new();
+
+    public Pantry Clone()
+        => new()
+        {
+            Id = Id,
+            FamilyId = FamilyId,
+            Items = Items.Select(i => i.Clone()).ToList(),
+        };
+}

--- a/Itemize/Models/Pantry/PantryItem.cs
+++ b/Itemize/Models/Pantry/PantryItem.cs
@@ -1,0 +1,83 @@
+namespace Itemize.Models.Pantry;
+
+public class PantryItem
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid PantryId { get; set; }
+        = Guid.Empty;
+
+    public Guid ProductId { get; set; }
+        = Guid.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string? Brand { get; set; }
+        = string.Empty;
+
+    public string? Category { get; set; }
+        = string.Empty;
+
+    public double Quantity { get; set; } = 0d;
+
+    public QuantityUnit Unit { get; set; } = QuantityUnit.Pack;
+
+    public double? MinimumThreshold { get; set; }
+        = null;
+
+    public DateTime? ExpirationDate { get; set; }
+        = null;
+
+    public DateTime AddedAt { get; set; } = DateTime.UtcNow;
+
+    public PantryItemState State { get; set; } = PantryItemState.Active;
+
+    public string? Notes { get; set; }
+        = null;
+
+    public bool IsFavorite { get; set; }
+        = false;
+
+    public bool IsLowStock
+        => MinimumThreshold.HasValue && Quantity <= MinimumThreshold.Value;
+
+    public string QuantityDisplay
+        => Unit switch
+        {
+            QuantityUnit.Gram => $"{Quantity:0} g",
+            QuantityUnit.Kilogram => $"{Quantity:0.##} kg",
+            QuantityUnit.Milliliter => $"{Quantity:0} ml",
+            QuantityUnit.Liter => $"{Quantity:0.##} l",
+            QuantityUnit.Piece => $"{Quantity:0} pz",
+            QuantityUnit.Bottle => $"{Quantity:0} bott.",
+            QuantityUnit.Can => $"{Quantity:0} latt.",
+            _ => $"{Quantity:0.##} conf."
+        };
+
+    public bool IsExpired(DateTime today)
+        => ExpirationDate.HasValue && ExpirationDate.Value.Date < today.Date;
+
+    public bool IsExpiringSoon(DateTime today, int thresholdDays)
+        => ExpirationDate.HasValue
+           && !IsExpired(today)
+           && (ExpirationDate.Value.Date - today.Date).TotalDays <= thresholdDays;
+
+    public PantryItem Clone()
+        => new()
+        {
+            Id = Id,
+            PantryId = PantryId,
+            ProductId = ProductId,
+            Name = Name,
+            Brand = Brand,
+            Category = Category,
+            Quantity = Quantity,
+            Unit = Unit,
+            MinimumThreshold = MinimumThreshold,
+            ExpirationDate = ExpirationDate,
+            AddedAt = AddedAt,
+            State = State,
+            Notes = Notes,
+            IsFavorite = IsFavorite,
+        };
+}

--- a/Itemize/Models/Pantry/PantryItemState.cs
+++ b/Itemize/Models/Pantry/PantryItemState.cs
@@ -1,0 +1,8 @@
+namespace Itemize.Models.Pantry;
+
+public enum PantryItemState
+{
+    Active,
+    Reserved,
+    Consumed,
+}

--- a/Itemize/Models/Pantry/PantrySection.cs
+++ b/Itemize/Models/Pantry/PantrySection.cs
@@ -1,0 +1,16 @@
+using System.Collections.ObjectModel;
+
+namespace Itemize.Models.Pantry;
+
+public class PantrySection
+{
+    public PantrySection(string title, IEnumerable<PantryItem> items)
+    {
+        Title = title;
+        Items = new ObservableCollection<PantryItem>(items);
+    }
+
+    public string Title { get; }
+
+    public ObservableCollection<PantryItem> Items { get; }
+}

--- a/Itemize/Models/Pantry/PantrySortOption.cs
+++ b/Itemize/Models/Pantry/PantrySortOption.cs
@@ -1,0 +1,25 @@
+namespace Itemize.Models.Pantry;
+
+public enum PantrySortType
+{
+    Alphabetical,
+    ExpirationDate,
+    AddedDate,
+    Category,
+}
+
+public class PantrySortOption
+{
+    public PantrySortOption(string label, PantrySortType sortType)
+    {
+        Label = label;
+        SortType = sortType;
+    }
+
+    public string Label { get; }
+
+    public PantrySortType SortType { get; }
+
+    public override string ToString()
+        => Label;
+}

--- a/Itemize/Models/Pantry/PantrySummary.cs
+++ b/Itemize/Models/Pantry/PantrySummary.cs
@@ -1,0 +1,29 @@
+namespace Itemize.Models.Pantry;
+
+public class PantrySummary
+{
+    public int TotalItems { get; init; }
+
+    public int UniqueProducts { get; init; }
+
+    public int ExpiringSoonCount { get; init; }
+
+    public int ExpiredCount { get; init; }
+
+    public int LowStockCount { get; init; }
+
+    public static PantrySummary FromItems(IEnumerable<PantryItem> items, int expiringThresholdDays)
+    {
+        var today = DateTime.Today;
+        var activeItems = items.Where(i => i.State == PantryItemState.Active).ToList();
+
+        return new PantrySummary
+        {
+            TotalItems = activeItems.Count,
+            UniqueProducts = activeItems.Select(i => i.ProductId).Distinct().Count(),
+            ExpiringSoonCount = activeItems.Count(i => i.IsExpiringSoon(today, expiringThresholdDays)),
+            ExpiredCount = activeItems.Count(i => i.IsExpired(today)),
+            LowStockCount = activeItems.Count(i => i.IsLowStock),
+        };
+    }
+}

--- a/Itemize/Models/Pantry/Product.cs
+++ b/Itemize/Models/Pantry/Product.cs
@@ -1,0 +1,40 @@
+namespace Itemize.Models.Pantry;
+
+public class Product
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+
+    public string Name { get; set; } = string.Empty;
+
+    public string? Brand { get; set; }
+        = string.Empty;
+
+    public string? Category { get; set; }
+        = string.Empty;
+
+    public string Barcode { get; set; } = string.Empty;
+
+    public QuantityUnit DefaultUnit { get; set; } = QuantityUnit.Pack;
+
+    public double DefaultQuantity { get; set; } = 1d;
+
+    public decimal? AveragePrice { get; set; }
+        = null;
+
+    public string? ImageUrl { get; set; }
+        = null;
+
+    public Product Clone()
+        => new()
+        {
+            Id = Id,
+            Name = Name,
+            Brand = Brand,
+            Category = Category,
+            Barcode = Barcode,
+            DefaultUnit = DefaultUnit,
+            DefaultQuantity = DefaultQuantity,
+            AveragePrice = AveragePrice,
+            ImageUrl = ImageUrl,
+        };
+}

--- a/Itemize/Models/Pantry/QuantityUnit.cs
+++ b/Itemize/Models/Pantry/QuantityUnit.cs
@@ -1,0 +1,13 @@
+namespace Itemize.Models.Pantry;
+
+public enum QuantityUnit
+{
+    Piece,
+    Pack,
+    Gram,
+    Kilogram,
+    Milliliter,
+    Liter,
+    Bottle,
+    Can,
+}

--- a/Itemize/Models/Pantry/RecipeSuggestion.cs
+++ b/Itemize/Models/Pantry/RecipeSuggestion.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+
+namespace Itemize.Models.Pantry;
+
+public class RecipeSuggestion
+{
+    public string Title { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+
+    public IReadOnlyList<string> Ingredients { get; set; } = Array.Empty<string>();
+
+    public string IngredientList => Ingredients.Any()
+        ? string.Join(", ", Ingredients)
+        : "Aggiungi ingredienti per suggerimenti personalizzati";
+}

--- a/Itemize/Models/Pantry/ShoppingItem.cs
+++ b/Itemize/Models/Pantry/ShoppingItem.cs
@@ -1,0 +1,57 @@
+namespace Itemize.Models.Pantry;
+
+public class ShoppingItem
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid SessionId { get; set; }
+        = Guid.Empty;
+
+    public Guid ProductId { get; set; }
+        = Guid.Empty;
+
+    public Product Product { get; set; } = null!;
+
+    public double Quantity { get; set; } = 0d;
+
+    public QuantityUnit Unit { get; set; } = QuantityUnit.Pack;
+
+    public decimal? Price { get; set; }
+        = null;
+
+    public DateTime AddedAt { get; set; } = DateTime.UtcNow;
+
+    public bool IsRemoved { get; set; }
+        = false;
+
+    public bool IsCommitted { get; set; }
+        = false;
+
+    public string QuantityDisplay
+        => Unit switch
+        {
+            QuantityUnit.Gram => $"{Quantity:0} g",
+            QuantityUnit.Kilogram => $"{Quantity:0.##} kg",
+            QuantityUnit.Milliliter => $"{Quantity:0} ml",
+            QuantityUnit.Liter => $"{Quantity:0.##} l",
+            QuantityUnit.Piece => $"{Quantity:0} pz",
+            QuantityUnit.Bottle => $"{Quantity:0} bott.",
+            QuantityUnit.Can => $"{Quantity:0} latt.",
+            _ => $"{Quantity:0.##} conf."
+        };
+
+    public ShoppingItem Clone()
+        => new()
+        {
+            Id = Id,
+            SessionId = SessionId,
+            ProductId = ProductId,
+            Product = Product.Clone(),
+            Quantity = Quantity,
+            Unit = Unit,
+            Price = Price,
+            AddedAt = AddedAt,
+            IsRemoved = IsRemoved,
+            IsCommitted = IsCommitted,
+        };
+}

--- a/Itemize/Models/Pantry/ShoppingSession.cs
+++ b/Itemize/Models/Pantry/ShoppingSession.cs
@@ -1,0 +1,36 @@
+namespace Itemize.Models.Pantry;
+
+public class ShoppingSession
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid FamilyId { get; set; }
+        = Guid.Empty;
+
+    public string Title { get; set; } = string.Empty;
+
+    public ShoppingSessionState State { get; set; } = ShoppingSessionState.Active;
+
+    public DateTime StartedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime? ConfirmedAt { get; set; }
+        = null;
+
+    public List<ShoppingItem> Items { get; set; } = new();
+
+    public decimal TotalAmount
+        => Items.Where(i => !i.IsRemoved)
+                 .Sum(i => i.Price.HasValue ? i.Price.Value : 0m);
+
+    public ShoppingSession Clone()
+        => new()
+        {
+            Id = Id,
+            FamilyId = FamilyId,
+            Title = Title,
+            State = State,
+            StartedAt = StartedAt,
+            ConfirmedAt = ConfirmedAt,
+            Items = Items.Select(i => i.Clone()).ToList(),
+        };
+}

--- a/Itemize/Models/Pantry/ShoppingSessionState.cs
+++ b/Itemize/Models/Pantry/ShoppingSessionState.cs
@@ -1,0 +1,9 @@
+namespace Itemize.Models.Pantry;
+
+public enum ShoppingSessionState
+{
+    Draft,
+    Active,
+    Completed,
+    Cancelled,
+}

--- a/Itemize/Models/Pantry/User.cs
+++ b/Itemize/Models/Pantry/User.cs
@@ -1,0 +1,21 @@
+namespace Itemize.Models.Pantry;
+
+public class User
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string Email { get; set; } = string.Empty;
+
+    public List<Guid> FamilyIds { get; set; } = new();
+
+    public User Clone()
+        => new()
+        {
+            Id = Id,
+            DisplayName = DisplayName,
+            Email = Email,
+            FamilyIds = new(FamilyIds),
+        };
+}

--- a/Itemize/PageModels/MainPageModel.cs
+++ b/Itemize/PageModels/MainPageModel.cs
@@ -1,174 +1,345 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+using System.Linq;
+
+
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Itemize.Models;
+using Microsoft.Maui.ApplicationModel;
 
-namespace Itemize.PageModels
+namespace Itemize.PageModels;
+
+public partial class MainPageModel : ObservableObject
 {
-    public partial class MainPageModel : ObservableObject, IProjectTaskPageModel
+    private const int ExpiringThresholdDays = 5;
+
+    private readonly IPantryStore _pantryStore;
+    private readonly RecipeSuggestionService _recipeSuggestionService;
+    private readonly FamilyContext _familyContext;
+
+    private bool _isInitialized;
+    private bool _isUpdatingFamilySelection;
+    private bool _isLoading;
+    private List<PantryItem> _currentItems = new();
+
+    public ObservableCollection<Family> Families { get; } = new();
+
+    public IReadOnlyList<PantrySortOption> SortOptions { get; }
+        = new List<PantrySortOption>
+        {
+            new("Alfabetico", PantrySortType.Alphabetical),
+            new("Data di scadenza", PantrySortType.ExpirationDate),
+            new("Data di aggiunta", PantrySortType.AddedDate),
+            new("Categoria", PantrySortType.Category),
+        };
+
+    [ObservableProperty]
+    private Family? _selectedFamily;
+
+    [ObservableProperty]
+    private PantrySortOption? _selectedSortOption;
+
+    [ObservableProperty]
+    private ObservableCollection<PantrySection> _pantrySections = new();
+
+    [ObservableProperty]
+    private ObservableCollection<PantryItem> _expiringItems = new();
+
+    [ObservableProperty]
+    private ObservableCollection<PantryItem> _lowStockItems = new();
+
+    [ObservableProperty]
+    private ObservableCollection<RecipeSuggestion> _recipeSuggestions = new();
+
+    [ObservableProperty]
+    private PantrySummary _summary = new()
     {
-        private bool _isNavigatedTo;
-        private bool _dataLoaded;
-        private readonly ProjectRepository _projectRepository;
-        private readonly TaskRepository _taskRepository;
-        private readonly CategoryRepository _categoryRepository;
-        private readonly ModalErrorHandler _errorHandler;
-        private readonly SeedDataService _seedDataService;
+        TotalItems = 0,
+        UniqueProducts = 0,
+        ExpiringSoonCount = 0,
+        ExpiredCount = 0,
+        LowStockCount = 0,
+    };
 
-        [ObservableProperty]
-        private List<CategoryChartData> _todoCategoryData = [];
+    [ObservableProperty]
+    private bool _isRefreshing;
 
-        [ObservableProperty]
-        private List<Brush> _todoCategoryColors = [];
+    [ObservableProperty]
+    private bool _isBusy;
 
-        [ObservableProperty]
-        private List<ProjectTask> _tasks = [];
+    public MainPageModel(IPantryStore pantryStore, RecipeSuggestionService recipeSuggestionService, FamilyContext familyContext)
+    {
+        _pantryStore = pantryStore;
+        _recipeSuggestionService = recipeSuggestionService;
+        _familyContext = familyContext;
 
-        [ObservableProperty]
-        private List<Project> _projects = [];
+        _selectedSortOption = SortOptions.First();
 
-        [ObservableProperty]
-        bool _isBusy;
+        _pantryStore.PantryChanged += OnPantryChanged;
+    }
 
-        [ObservableProperty]
-        bool _isRefreshing;
-
-        [ObservableProperty]
-        private string _today = DateTime.Now.ToString("dddd, MMM d");
-
-        public bool HasCompletedTasks
-            => Tasks?.Any(t => t.IsCompleted) ?? false;
-
-        public MainPageModel(SeedDataService seedDataService, ProjectRepository projectRepository,
-            TaskRepository taskRepository, CategoryRepository categoryRepository, ModalErrorHandler errorHandler)
+    [RelayCommand]
+    private async Task Appearing()
+    {
+        if (_isInitialized)
         {
-            _projectRepository = projectRepository;
-            _taskRepository = taskRepository;
-            _categoryRepository = categoryRepository;
-            _errorHandler = errorHandler;
-            _seedDataService = seedDataService;
+            if (SelectedFamily is not null)
+            {
+                await RefreshInternalAsync(SelectedFamily.Id);
+            }
+            return;
         }
 
-        private async Task LoadData()
+        _isInitialized = true;
+        await LoadFamiliesAsync();
+        if (SelectedFamily is not null)
         {
-            try
-            {
-                IsBusy = true;
+            await RefreshInternalAsync(SelectedFamily.Id);
+        }
+    }
 
-                Projects = await _projectRepository.ListAsync();
-
-                var chartData = new List<CategoryChartData>();
-                var chartColors = new List<Brush>();
-
-                var categories = await _categoryRepository.ListAsync();
-                foreach (var category in categories)
-                {
-                    chartColors.Add(category.ColorBrush);
-
-                    var ps = Projects.Where(p => p.CategoryID == category.ID).ToList();
-                    int tasksCount = ps.SelectMany(p => p.Tasks).Count();
-
-                    chartData.Add(new(category.Title, tasksCount));
-                }
-
-                TodoCategoryData = chartData;
-                TodoCategoryColors = chartColors;
-
-                Tasks = await _taskRepository.ListAsync();
-            }
-            finally
-            {
-                IsBusy = false;
-                OnPropertyChanged(nameof(HasCompletedTasks));
-            }
+    [RelayCommand]
+    private async Task Refresh()
+    {
+        if (SelectedFamily is null)
+        {
+            return;
         }
 
-        private async Task InitData(SeedDataService seedDataService)
+        IsRefreshing = true;
+        await RefreshInternalAsync(SelectedFamily.Id);
+        IsRefreshing = false;
+    }
+
+    [RelayCommand]
+    private async Task StartShopping()
+    {
+        if (SelectedFamily is null)
         {
-            bool isSeeded = Preferences.Default.ContainsKey("is_seeded");
-
-            if (!isSeeded)
-            {
-                await seedDataService.LoadSeedDataAsync();
-            }
-
-            Preferences.Default.Set("is_seeded", true);
-            await Refresh();
+            return;
         }
 
-        [RelayCommand]
-        private async Task Refresh()
+        await Shell.Current.GoToAsync("//shopping");
+    }
+
+    [RelayCommand]
+    private async Task EditItem(PantryItem item)
+    {
+        if (SelectedFamily is null)
         {
-            try
-            {
-                IsRefreshing = true;
-                await LoadData();
-            }
-            catch (Exception e)
-            {
-                _errorHandler.HandleError(e);
-            }
-            finally
-            {
-                IsRefreshing = false;
-            }
+            return;
         }
 
-        [RelayCommand]
-        private void NavigatedTo() =>
-            _isNavigatedTo = true;
+        var result = await Shell.Current.DisplayPromptAsync(
+            "Modifica quantità",
+            $"Aggiorna la quantità per {item.Name}",
+            keyboard: Keyboard.Numeric,
+            initialValue: item.Quantity.ToString("0.##", CultureInfo.CurrentCulture));
 
-        [RelayCommand]
-        private void NavigatedFrom() =>
-            _isNavigatedTo = false;
-
-        [RelayCommand]
-        private async Task Appearing()
+        if (string.IsNullOrWhiteSpace(result))
         {
-            if (!_dataLoaded)
-            {
-                await InitData(_seedDataService);
-                _dataLoaded = true;
-                await Refresh();
-            }
-            // This means we are being navigated to
-            else if (!_isNavigatedTo)
-            {
-                await Refresh();
-            }
+            return;
         }
 
-        [RelayCommand]
-        private Task TaskCompleted(ProjectTask task)
+        if (!TryParseQuantity(result, out var quantity) || quantity < 0)
         {
-            OnPropertyChanged(nameof(HasCompletedTasks));
-            return _taskRepository.SaveItemAsync(task);
+            await AppShell.DisplaySnackbarAsync("Quantità non valida.");
+            return;
         }
 
-        [RelayCommand]
-        private Task AddTask()
-            => Shell.Current.GoToAsync($"task");
+        var updated = item.Clone();
+        updated.Quantity = quantity;
 
-        [RelayCommand]
-        private Task NavigateToProject(Project project)
-            => Shell.Current.GoToAsync($"project?id={project.ID}");
+        await _pantryStore.UpdatePantryItemAsync(SelectedFamily.Id, updated);
+        await RefreshInternalAsync(SelectedFamily.Id);
+        await AppShell.DisplayToastAsync($"{item.Name} aggiornato");
+    }
 
-        [RelayCommand]
-        private Task NavigateToTask(ProjectTask task)
-            => Shell.Current.GoToAsync($"task?id={task.ID}");
-
-        [RelayCommand]
-        private async Task CleanTasks()
+    [RelayCommand]
+    private async Task DeleteItem(PantryItem item)
+    {
+        if (SelectedFamily is null)
         {
-            var completedTasks = Tasks.Where(t => t.IsCompleted).ToList();
-            foreach (var task in completedTasks)
+            return;
+        }
+
+        var confirm = await Shell.Current.DisplayAlert(
+            "Rimuovi prodotto",
+            $"Vuoi rimuovere {item.Name} dalla dispensa?",
+            "Rimuovi",
+            "Annulla");
+
+        if (!confirm)
+        {
+            return;
+        }
+
+        await _pantryStore.DeletePantryItemAsync(SelectedFamily.Id, item.Id);
+        await RefreshInternalAsync(SelectedFamily.Id);
+        await AppShell.DisplayToastAsync($"{item.Name} rimosso");
+    }
+
+    partial void OnSelectedFamilyChanged(Family? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        if (_isUpdatingFamilySelection)
+        {
+            return;
+        }
+
+        if (_familyContext.SelectedFamilyId != value.Id)
+        {
+            _familyContext.SelectedFamilyId = value.Id;
+        }
+
+        if (_isInitialized)
+        {
+            _ = RefreshInternalAsync(value.Id);
+        }
+    }
+
+    partial void OnSelectedSortOptionChanged(PantrySortOption? value)
+    {
+        if (value is null || !_currentItems.Any())
+        {
+            return;
+        }
+
+        UpdateSections(_currentItems);
+    }
+
+    private async Task LoadFamiliesAsync()
+    {
+        var families = await _pantryStore.GetFamiliesAsync();
+
+        _isUpdatingFamilySelection = true;
+        Families.Clear();
+        foreach (var family in families)
+        {
+            Families.Add(family);
+        }
+
+        Family? selected = null;
+        if (_familyContext.SelectedFamilyId is Guid currentId)
+        {
+            selected = Families.FirstOrDefault(f => f.Id == currentId);
+        }
+
+        SelectedFamily = selected ?? Families.FirstOrDefault();
+        _isUpdatingFamilySelection = false;
+    }
+
+    private async Task RefreshInternalAsync(Guid familyId)
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        _isLoading = true;
+        try
+        {
+            IsBusy = true;
+            var pantry = await _pantryStore.GetPantryAsync(familyId);
+            var items = pantry.Items
+                .Where(i => i.State == PantryItemState.Active)
+                .Select(i => i.Clone())
+                .ToList();
+
+            _currentItems = items;
+
+            Summary = PantrySummary.FromItems(items, ExpiringThresholdDays);
+            UpdateHighlights(items);
+            UpdateSections(items);
+            UpdateRecipes(items);
+        }
+        finally
+        {
+            IsBusy = false;
+            _isLoading = false;
+        }
+    }
+
+    private void UpdateHighlights(List<PantryItem> items)
+    {
+        var today = DateTime.Today;
+        var expiring = items
+            .Where(i => i.IsExpiringSoon(today, ExpiringThresholdDays) || i.IsExpired(today))
+            .OrderBy(i => i.ExpirationDate ?? DateTime.MaxValue)
+            .Select(i => i.Clone())
+            .ToList();
+
+        ExpiringItems = new ObservableCollection<PantryItem>(expiring);
+
+        var lowStock = items
+            .Where(i => i.IsLowStock)
+            .OrderBy(i => i.Quantity)
+            .Select(i => i.Clone())
+            .ToList();
+
+        LowStockItems = new ObservableCollection<PantryItem>(lowStock);
+    }
+
+    private void UpdateSections(List<PantryItem> items)
+    {
+        IEnumerable<PantrySection> sections;
+        if (SelectedSortOption?.SortType == PantrySortType.Category)
+        {
+            sections = items
+                .GroupBy(i => string.IsNullOrWhiteSpace(i.Category) ? "Altro" : i.Category)
+                .OrderBy(g => g.Key)
+                .Select(g => new PantrySection(g.Key, SortItems(g, PantrySortType.Alphabetical)));
+        }
+        else
+        {
+            var sorted = SortItems(items, SelectedSortOption?.SortType ?? PantrySortType.Alphabetical);
+            sections = new[] { new PantrySection("Tutti i prodotti", sorted) };
+        }
+
+        PantrySections = new ObservableCollection<PantrySection>(sections);
+    }
+
+    private void UpdateRecipes(List<PantryItem> items)
+    {
+        var suggestions = _recipeSuggestionService.BuildSuggestions(items);
+        RecipeSuggestions = new ObservableCollection<RecipeSuggestion>(suggestions);
+    }
+
+    private static IEnumerable<PantryItem> SortItems(IEnumerable<PantryItem> items, PantrySortType sortType)
+    {
+        return sortType switch
+        {
+            PantrySortType.ExpirationDate => items.OrderBy(i => i.ExpirationDate ?? DateTime.MaxValue),
+            PantrySortType.AddedDate => items.OrderByDescending(i => i.AddedAt),
+            PantrySortType.Category => items.OrderBy(i => i.Name),
+            _ => items.OrderBy(i => i.Name),
+        };
+    }
+
+    private static bool TryParseQuantity(string text, out double value)
+    {
+        return double.TryParse(text, NumberStyles.Float, CultureInfo.CurrentCulture, out value)
+            || double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+    }
+
+    private void OnPantryChanged(object? sender, PantryChangedEventArgs e)
+    {
+        if (SelectedFamily?.Id != e.FamilyId)
+        {
+            return;
+        }
+
+        MainThread.BeginInvokeOnMainThread(async () =>
+        {
+            if (SelectedFamily is not null)
             {
-                await _taskRepository.DeleteItemAsync(task);
-                Tasks.Remove(task);
+                await RefreshInternalAsync(SelectedFamily.Id);
             }
-
-            OnPropertyChanged(nameof(HasCompletedTasks));
-            Tasks = new(Tasks);
-            await AppShell.DisplayToastAsync("All cleaned up!");
-        }
+        });
     }
 }

--- a/Itemize/PageModels/ShoppingSessionPageModel.cs
+++ b/Itemize/PageModels/ShoppingSessionPageModel.cs
@@ -1,0 +1,439 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+
+
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+
+namespace Itemize.PageModels;
+
+public partial class ShoppingSessionPageModel : ObservableObject
+{
+    private readonly IPantryStore _pantryStore;
+    private readonly IProductCatalog _productCatalog;
+    private readonly FamilyContext _familyContext;
+
+    private bool _isInitialized;
+    private bool _isUpdatingSelection;
+
+    public ObservableCollection<Family> Families { get; } = new();
+
+    [ObservableProperty]
+    private Family? _selectedFamily;
+
+    [ObservableProperty]
+    private ShoppingSession? _session;
+
+    [ObservableProperty]
+    private ObservableCollection<ShoppingItem> _items = new();
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    [ObservableProperty]
+    private bool _isManualEntryVisible;
+
+    [ObservableProperty]
+    private string _manualBarcode = string.Empty;
+
+    [ObservableProperty]
+    private string _sessionTitle = string.Empty;
+
+    [ObservableProperty]
+    private decimal _estimatedTotal;
+
+    public bool HasActiveSession => Session?.State == ShoppingSessionState.Active;
+
+    public bool HasItems => Items.Any();
+
+    public ShoppingSessionPageModel(IPantryStore pantryStore, IProductCatalog productCatalog, FamilyContext familyContext)
+    {
+        _pantryStore = pantryStore;
+        _productCatalog = productCatalog;
+        _familyContext = familyContext;
+
+        _pantryStore.ShoppingSessionChanged += OnShoppingSessionChanged;
+        _familyContext.PropertyChanged += OnFamilyContextChanged;
+    }
+
+    [RelayCommand]
+    private async Task Appearing()
+    {
+        if (!_isInitialized)
+        {
+            await LoadFamiliesAsync();
+            _isInitialized = true;
+        }
+
+        if (SelectedFamily is not null)
+        {
+            await LoadSessionAsync(SelectedFamily.Id);
+        }
+    }
+
+    [RelayCommand]
+    private Task ToggleManualEntry()
+    {
+        IsManualEntryVisible = !IsManualEntryVisible;
+        return Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private async Task StartNewSession()
+    {
+        if (SelectedFamily is null)
+        {
+            await AppShell.DisplaySnackbarAsync("Seleziona una famiglia per iniziare.");
+            return;
+        }
+
+        var defaultTitle = $"Spesa del {DateTime.Now:dd MMMM}";
+        var title = await Shell.Current.DisplayPromptAsync(
+            "Nuova spesa",
+            "Dai un nome alla sessione",
+            accept: "Crea",
+            cancel: "Annulla",
+            initialValue: defaultTitle);
+
+        if (title is null)
+        {
+            return;
+        }
+
+        title = string.IsNullOrWhiteSpace(title) ? defaultTitle : title.Trim();
+
+        var session = await _pantryStore.StartSessionAsync(SelectedFamily.Id, title);
+        Session = session;
+        SessionTitle = session.Title;
+        Items = new ObservableCollection<ShoppingItem>(session.Items.Where(i => !i.IsRemoved).Select(i => i.Clone()));
+        EstimatedTotal = Items.Sum(i => i.Price ?? 0m);
+        OnPropertyChanged(nameof(HasActiveSession));
+        OnPropertyChanged(nameof(HasItems));
+        await AppShell.DisplayToastAsync("Sessione di spesa avviata");
+    }
+
+    [RelayCommand]
+    private async Task ScanProduct()
+    {
+        if (Session is null)
+        {
+            await AppShell.DisplaySnackbarAsync("Avvia prima una sessione di spesa.");
+            return;
+        }
+
+        var products = await _productCatalog.GetProductsAsync();
+        if (!products.Any())
+        {
+            await AppShell.DisplaySnackbarAsync("Catalogo prodotti vuoto.");
+            return;
+        }
+
+        var options = products
+            .Select(p => $"{p.Name} ({p.Brand})")
+            .ToArray();
+
+        var selectedLabel = await Shell.Current.DisplayActionSheet(
+            "Simula scansione",
+            "Annulla",
+            null,
+            options);
+
+        if (string.IsNullOrWhiteSpace(selectedLabel) || selectedLabel == "Annulla")
+        {
+            return;
+        }
+
+        var product = products.First(p => $"{p.Name} ({p.Brand})" == selectedLabel);
+        await PromptAndAddProductAsync(product);
+    }
+
+    [RelayCommand]
+    private async Task AddManualProduct()
+    {
+        if (Session is null)
+        {
+            await AppShell.DisplaySnackbarAsync("Avvia prima una sessione di spesa.");
+            return;
+        }
+
+        var barcode = ManualBarcode.Trim();
+        if (string.IsNullOrWhiteSpace(barcode))
+        {
+            await AppShell.DisplaySnackbarAsync("Inserisci un codice valido.");
+            return;
+        }
+
+        var product = await _productCatalog.GetByBarcodeAsync(barcode);
+        if (product is null)
+        {
+            await AppShell.DisplaySnackbarAsync("Prodotto non trovato in catalogo.");
+            return;
+        }
+
+        ManualBarcode = string.Empty;
+        IsManualEntryVisible = false;
+        await PromptAndAddProductAsync(product);
+    }
+
+    [RelayCommand]
+    private async Task RemoveItem(ShoppingItem item)
+    {
+        if (Session is null)
+        {
+            return;
+        }
+
+        var confirm = await Shell.Current.DisplayAlert(
+            "Rimuovi prodotto",
+            $"Vuoi rimuovere {item.Product.Name}?",
+            "Rimuovi",
+            "Annulla");
+
+        if (!confirm)
+        {
+            return;
+        }
+
+        await _pantryStore.RemoveShoppingItemAsync(Session.Id, item.Id);
+    }
+
+    [RelayCommand]
+    private async Task EditItem(ShoppingItem item)
+    {
+        if (Session is null)
+        {
+            return;
+        }
+
+        var result = await Shell.Current.DisplayPromptAsync(
+            "Modifica quantità",
+            $"Aggiorna la quantità per {item.Product.Name}",
+            keyboard: Keyboard.Numeric,
+            initialValue: item.Quantity.ToString("0.##", CultureInfo.CurrentCulture));
+
+        if (string.IsNullOrWhiteSpace(result))
+        {
+            return;
+        }
+
+        if (!TryParseQuantity(result, out var quantity) || quantity <= 0)
+        {
+            await AppShell.DisplaySnackbarAsync("Quantità non valida.");
+            return;
+        }
+
+        var updated = item.Clone();
+        updated.Quantity = quantity;
+        updated.Price = item.Product.AveragePrice.HasValue
+            ? item.Product.AveragePrice.Value * (decimal)quantity
+            : item.Price;
+
+        await _pantryStore.UpdateShoppingItemAsync(Session.Id, updated);
+    }
+
+    [RelayCommand]
+    private async Task ConfirmSession()
+    {
+        if (Session is null || !Items.Any())
+        {
+            await AppShell.DisplaySnackbarAsync("Aggiungi almeno un prodotto prima di confermare.");
+            return;
+        }
+
+        var confirm = await Shell.Current.DisplayAlert(
+            "Conferma spesa",
+            "I prodotti verranno aggiunti alla dispensa. Confermi?",
+            "Conferma",
+            "Annulla");
+
+        if (!confirm)
+        {
+            return;
+        }
+
+        await _pantryStore.ConfirmSessionAsync(Session.Id, DateTime.Now);
+        await AppShell.DisplayToastAsync("Spesa confermata! I prodotti sono in dispensa.");
+    }
+
+    private async Task LoadFamiliesAsync()
+    {
+        var families = await _pantryStore.GetFamiliesAsync();
+        _isUpdatingSelection = true;
+        Families.Clear();
+        foreach (var family in families)
+        {
+            Families.Add(family);
+        }
+
+        Family? target = null;
+        if (_familyContext.SelectedFamilyId is Guid familyId)
+        {
+            target = Families.FirstOrDefault(f => f.Id == familyId);
+        }
+
+        SelectedFamily = target ?? Families.FirstOrDefault();
+        _isUpdatingSelection = false;
+    }
+
+    private async Task LoadSessionAsync(Guid familyId)
+    {
+        IsBusy = true;
+        try
+        {
+            var session = await _pantryStore.GetCurrentSessionAsync(familyId);
+            Session = session;
+            SessionTitle = session?.Title ?? string.Empty;
+            if (session is null)
+            {
+                Items = new ObservableCollection<ShoppingItem>();
+                EstimatedTotal = 0;
+            }
+            else
+            {
+                var visibleItems = session.Items
+                    .Where(i => !i.IsRemoved)
+                    .Select(i => i.Clone())
+                    .ToList();
+                Items = new ObservableCollection<ShoppingItem>(visibleItems);
+                EstimatedTotal = visibleItems.Sum(i => i.Price ?? 0m);
+            }
+
+            OnPropertyChanged(nameof(HasActiveSession));
+            OnPropertyChanged(nameof(HasItems));
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    partial void OnSelectedFamilyChanged(Family? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        if (_isUpdatingSelection)
+        {
+            return;
+        }
+
+        if (_familyContext.SelectedFamilyId != value.Id)
+        {
+            _familyContext.SelectedFamilyId = value.Id;
+        }
+
+        _ = LoadSessionAsync(value.Id);
+    }
+
+    partial void OnSessionChanged(ShoppingSession? value)
+    {
+        OnPropertyChanged(nameof(HasActiveSession));
+    }
+
+    partial void OnItemsChanged(ObservableCollection<ShoppingItem> value)
+    {
+        EstimatedTotal = value.Sum(i => i.Price ?? 0m);
+        OnPropertyChanged(nameof(HasItems));
+    }
+
+    private async Task PromptAndAddProductAsync(Product product)
+    {
+        if (Session is null)
+        {
+            return;
+        }
+
+        var quantityInput = await Shell.Current.DisplayPromptAsync(
+            product.Name,
+            "Quante unità vuoi aggiungere?",
+            keyboard: Keyboard.Numeric,
+            initialValue: product.DefaultQuantity.ToString("0.##", CultureInfo.CurrentCulture));
+
+        if (string.IsNullOrWhiteSpace(quantityInput))
+        {
+            return;
+        }
+
+        if (!TryParseQuantity(quantityInput, out var quantity) || quantity <= 0)
+        {
+            await AppShell.DisplaySnackbarAsync("Quantità non valida.");
+            return;
+        }
+
+        var shoppingItem = new ShoppingItem
+        {
+            SessionId = Session.Id,
+            ProductId = product.Id,
+            Product = product,
+            Quantity = quantity,
+            Unit = product.DefaultUnit,
+            Price = product.AveragePrice.HasValue
+                ? product.AveragePrice.Value * (decimal)quantity
+                : null,
+        };
+
+        await _pantryStore.AddOrUpdateShoppingItemAsync(Session.Id, shoppingItem);
+    }
+
+    private void OnShoppingSessionChanged(object? sender, ShoppingSessionChangedEventArgs e)
+    {
+        if (SelectedFamily?.Id != e.FamilyId)
+        {
+            return;
+        }
+
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            if (e.Session.State != ShoppingSessionState.Active)
+            {
+                Session = null;
+                SessionTitle = string.Empty;
+                Items = new ObservableCollection<ShoppingItem>();
+                EstimatedTotal = 0;
+            }
+            else
+            {
+                Session = e.Session;
+                SessionTitle = e.Session.Title;
+                var visibleItems = e.Session.Items
+                    .Where(i => !i.IsRemoved)
+                    .Select(i => i.Clone())
+                    .ToList();
+                Items = new ObservableCollection<ShoppingItem>(visibleItems);
+                EstimatedTotal = visibleItems.Sum(i => i.Price ?? 0m);
+            }
+
+            OnPropertyChanged(nameof(HasActiveSession));
+            OnPropertyChanged(nameof(HasItems));
+        });
+    }
+
+    private void OnFamilyContextChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(FamilyContext.SelectedFamilyId))
+        {
+            return;
+        }
+
+        if (_familyContext.SelectedFamilyId is Guid id)
+        {
+            var target = Families.FirstOrDefault(f => f.Id == id);
+            if (target is not null && SelectedFamily?.Id != target.Id)
+            {
+                SelectedFamily = target;
+            }
+        }
+    }
+
+    private static bool TryParseQuantity(string text, out double value)
+    {
+        return double.TryParse(text, NumberStyles.Float, CultureInfo.CurrentCulture, out value)
+            || double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+    }
+}

--- a/Itemize/Pages/MainPage.xaml
+++ b/Itemize/Pages/MainPage.xaml
@@ -1,85 +1,263 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pageModels="clr-namespace:Itemize.PageModels"             
-             xmlns:models="clr-namespace:Itemize.Models"
-             xmlns:controls="clr-namespace:Itemize.Pages.Controls"
-             xmlns:pullToRefresh="clr-namespace:Syncfusion.Maui.Toolkit.PullToRefresh;assembly=Syncfusion.Maui.Toolkit"
+             xmlns:pageModels="clr-namespace:Itemize.PageModels"
+             xmlns:pantry="clr-namespace:Itemize.Models.Pantry"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="Itemize.Pages.MainPage"
              x:DataType="pageModels:MainPageModel"
-             Title="{Binding Today}">
+             Title="Dispensa">
 
     <ContentPage.Behaviors>
-        <toolkit:EventToCommandBehavior
-                EventName="NavigatedTo"
-                Command="{Binding NavigatedToCommand}" />
-        <toolkit:EventToCommandBehavior
-                EventName="NavigatedFrom"
-                Command="{Binding NavigatedFromCommand}" />
-        <toolkit:EventToCommandBehavior
-                EventName="Appearing"                
-                Command="{Binding AppearingCommand}" />
+        <toolkit:EventToCommandBehavior EventName="Appearing"
+                                        Command="{Binding AppearingCommand}" />
     </ContentPage.Behaviors>
 
     <ContentPage.Resources>
         <ResourceDictionary>
-            <toolkit:InvertedBoolConverter x:Key="InvertedBoolConverter" />
+            <Style x:Key="SectionTitle" TargetType="Label">
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="FontAttributes" Value="Bold" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource DarkOnLightBackground}, Dark={StaticResource LightOnDarkBackground}}" />
+                <Setter Property="Margin" Value="0,20,0,10" />
+            </Style>
+            <Style x:Key="CardTitle" TargetType="Label">
+                <Setter Property="FontAttributes" Value="SemiBold" />
+                <Setter Property="FontSize" Value="16" />
+            </Style>
+            <Style x:Key="CardSubtitle" TargetType="Label">
+                <Setter Property="FontSize" Value="13" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray300}}" />
+            </Style>
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <Grid>
-        <pullToRefresh:SfPullToRefresh
-            IsRefreshing="{Binding IsRefreshing}"
-            RefreshCommand="{Binding RefreshCommand}">
-            <pullToRefresh:SfPullToRefresh.PullableContent>
-                <ScrollView>
-                    <VerticalStackLayout Spacing="{StaticResource LayoutSpacing}" Padding="{StaticResource LayoutPadding}">
-                        <controls:CategoryChart />
-                        <Label Text="Projects" Style="{StaticResource Title2}"/>
-                        <ScrollView Orientation="Horizontal" Margin="-30,0">
-                            <HorizontalStackLayout 
-                                Spacing="15" Padding="30,0"
-                                BindableLayout.ItemsSource="{Binding Projects}">
-                                <BindableLayout.ItemTemplate>
-                                    <DataTemplate x:DataType="models:Project">
-                                        <controls:ProjectCardView WidthRequest="200">
-                                            <controls:ProjectCardView.GestureRecognizers>
-                                                <TapGestureRecognizer Command="{Binding NavigateToProjectCommand, Source={RelativeSource AncestorType={x:Type pageModels:MainPageModel}}, x:DataType=pageModels:MainPageModel}" CommandParameter="{Binding .}"/>
-                                            </controls:ProjectCardView.GestureRecognizers>
-                                        </controls:ProjectCardView>
-                                    </DataTemplate>
-                                </BindableLayout.ItemTemplate>
-                            </HorizontalStackLayout>
-                        </ScrollView>
-                        <Grid HeightRequest="44">
-                            <Label Text="Tasks" Style="{StaticResource Title2}" VerticalOptions="Center"/>
-                            <ImageButton 
-                                Source="{StaticResource IconClean}"
-                                HorizontalOptions="End"
-                                VerticalOptions="Center"
-                                Aspect="Center"
-                                HeightRequest="44"
-                                WidthRequest="44"
-                                IsVisible="{Binding HasCompletedTasks}"
-                                Command="{Binding CleanTasksCommand}"
-                                SemanticProperties.Description="Clean tasks" />
-                        </Grid>
-                        <VerticalStackLayout Spacing="15"
-                            BindableLayout.ItemsSource="{Binding Tasks}">
-                            <BindableLayout.ItemTemplate>
-                                <DataTemplate>
-                                    <controls:TaskView TaskCompletedCommand="{Binding TaskCompletedCommand, Source={RelativeSource AncestorType={x:Type pageModels:MainPageModel}}, x:DataType=pageModels:MainPageModel}" />
-                                </DataTemplate>
-                            </BindableLayout.ItemTemplate>
+        <RefreshView IsRefreshing="{Binding IsRefreshing}"
+                     Command="{Binding RefreshCommand}">
+            <ScrollView>
+                <VerticalStackLayout Spacing="20"
+                                      Padding="20">
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                        <VerticalStackLayout Spacing="2">
+                            <Label Text="La tua dispensa" FontSize="28" FontAttributes="Bold" />
+                            <Label Text="Gestisci ciò che hai in casa in tempo reale"
+                                   TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}" />
                         </VerticalStackLayout>
-                    </VerticalStackLayout>
-                </ScrollView>
-            </pullToRefresh:SfPullToRefresh.PullableContent>
-        </pullToRefresh:SfPullToRefresh>
+                        <Button Text="Inizia spesa"
+                                Command="{Binding StartShoppingCommand}"
+                                HorizontalOptions="End"
+                                VerticalOptions="Center" />
+                    </Grid>
 
-        <controls:AddButton 
-            IsEnabled="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-            Command="{Binding AddTaskCommand}" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                        <VerticalStackLayout Spacing="4">
+                            <Label Text="Famiglia" FontAttributes="SemiBold" />
+                            <Picker ItemsSource="{Binding Families}"
+                                    ItemDisplayBinding="{Binding Name}"
+                                    SelectedItem="{Binding SelectedFamily}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="4"
+                                             HorizontalOptions="End"
+                                             VerticalOptions="Center">
+                            <Label Text="Ordinamento" FontAttributes="SemiBold" />
+                            <Picker ItemsSource="{Binding SortOptions}"
+                                    SelectedItem="{Binding SelectedSortOption}" />
+                        </VerticalStackLayout>
+                    </Grid>
+
+                    <Border BackgroundColor="{AppThemeBinding Light={StaticResource PrimaryContainer}, Dark={StaticResource DarkContainer}}"
+                            StrokeShape="RoundRectangle 20"
+                            Padding="20">
+                        <Grid ColumnDefinitions="*,*,*" ColumnSpacing="16">
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="Totale prodotti" Style="{StaticResource CardSubtitle}" />
+                                <Label Text="{Binding Summary.TotalItems}" FontSize="24" FontAttributes="Bold" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="In scadenza" Style="{StaticResource CardSubtitle}" />
+                                <Label Text="{Binding Summary.ExpiringSoonCount}" FontSize="24" FontAttributes="Bold" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="Scorte basse" Style="{StaticResource CardSubtitle}" />
+                                <Label Text="{Binding Summary.LowStockCount}" FontSize="24" FontAttributes="Bold" />
+                            </VerticalStackLayout>
+                        </Grid>
+                    </Border>
+
+                    <VerticalStackLayout>
+                        <Label Text="In scadenza" Style="{StaticResource SectionTitle}" />
+                        <CollectionView ItemsSource="{Binding ExpiringItems}"
+                                        ItemsLayout="HorizontalList"
+                                        HeightRequest="170"
+                                        SelectionMode="None">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="pantry:PantryItem">
+                                    <Border StrokeShape="RoundRectangle 18"
+                                            BackgroundColor="{AppThemeBinding Light={StaticResource SecondaryContainer}, Dark={StaticResource DarkContainer}}"
+                                            Padding="16"
+                                            Margin="0,0,12,0"
+                                            WidthRequest="220">
+                                        <VerticalStackLayout Spacing="8">
+                                            <Label Text="{Binding Name}" Style="{StaticResource CardTitle}" />
+                                            <Label Text="{Binding Brand}" Style="{StaticResource CardSubtitle}" />
+                                            <Label Text="{Binding QuantityDisplay}" />
+                                            <Label Text="{Binding ExpirationDate, StringFormat='Scade il {0:dd MMM}'}"
+                                                   TextColor="{AppThemeBinding Light={StaticResource Warning}, Dark={StaticResource Warning}}" />
+                                        </VerticalStackLayout>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                            <CollectionView.EmptyView>
+                                <Border StrokeShape="RoundRectangle 18"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceContainer}, Dark={StaticResource DarkSurface}}"
+                                        Padding="20"
+                                        WidthRequest="220">
+                                    <VerticalStackLayout Spacing="6">
+                                        <Label Text="Nessun prodotto in scadenza immediata" />
+                                        <Label Text="Continua così!" Style="{StaticResource CardSubtitle}" />
+                                    </VerticalStackLayout>
+                                </Border>
+                            </CollectionView.EmptyView>
+                        </CollectionView>
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout>
+                        <Label Text="Scorte da reintegrare" Style="{StaticResource SectionTitle}" />
+                        <CollectionView ItemsSource="{Binding LowStockItems}"
+                                        ItemsLayout="HorizontalList"
+                                        HeightRequest="150"
+                                        SelectionMode="None">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="pantry:PantryItem">
+                                    <Border StrokeShape="RoundRectangle 18"
+                                            BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceContainer}, Dark={StaticResource DarkSurface}}"
+                                            Padding="16"
+                                            Margin="0,0,12,0"
+                                            WidthRequest="200">
+                                        <VerticalStackLayout Spacing="6">
+                                            <Label Text="{Binding Name}" Style="{StaticResource CardTitle}" />
+                                            <Label Text="Quantità: {Binding QuantityDisplay}" />
+                                            <Label Text="{Binding MinimumThreshold, StringFormat='Soglia minima: {0:0.##}'}" Style="{StaticResource CardSubtitle}" />
+                                        </VerticalStackLayout>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                            <CollectionView.EmptyView>
+                                <Border StrokeShape="RoundRectangle 18"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceContainer}, Dark={StaticResource DarkSurface}}"
+                                        Padding="20"
+                                        WidthRequest="220">
+                                    <VerticalStackLayout Spacing="6">
+                                        <Label Text="Tutte le scorte sono sopra la soglia" />
+                                    </VerticalStackLayout>
+                                </Border>
+                            </CollectionView.EmptyView>
+                        </CollectionView>
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout>
+                        <Label Text="Suggerimenti ricette" Style="{StaticResource SectionTitle}" />
+                        <CollectionView ItemsSource="{Binding RecipeSuggestions}"
+                                        ItemsLayout="HorizontalList"
+                                        HeightRequest="170"
+                                        SelectionMode="None">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="pantry:RecipeSuggestion">
+                                    <Border StrokeShape="RoundRectangle 18"
+                                            BackgroundColor="{AppThemeBinding Light={StaticResource PrimaryContainer}, Dark={StaticResource DarkContainer}}"
+                                            Padding="18"
+                                            Margin="0,0,12,0"
+                                            WidthRequest="240">
+                                        <VerticalStackLayout Spacing="8">
+                                            <Label Text="{Binding Title}" Style="{StaticResource CardTitle}" />
+                                            <Label Text="{Binding Description}" Style="{StaticResource CardSubtitle}" />
+                                            <Label Text="Ingredienti:" FontAttributes="Bold" />
+                                            <Label Text="{Binding IngredientList}"
+                                                   LineBreakMode="WordWrap" />
+                                        </VerticalStackLayout>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                            <CollectionView.EmptyView>
+                                <Border StrokeShape="RoundRectangle 18"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceContainer}, Dark={StaticResource DarkSurface}}"
+                                        Padding="20"
+                                        WidthRequest="240">
+                                    <Label Text="Aggiungi più prodotti per ricevere suggerimenti personalizzati" />
+                                </Border>
+                            </CollectionView.EmptyView>
+                        </CollectionView>
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout>
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                            <Label Text="Dispensa" Style="{StaticResource SectionTitle}" Margin="0" />
+                            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
+                        </Grid>
+                        <CollectionView ItemsSource="{Binding PantrySections}"
+                                        IsGrouped="True"
+                                        SelectionMode="None">
+                            <CollectionView.GroupHeaderTemplate>
+                                <DataTemplate x:DataType="pantry:PantrySection">
+                                    <Label Text="{Binding Title}" FontAttributes="Bold" Margin="0,12,0,4" />
+                                </DataTemplate>
+                            </CollectionView.GroupHeaderTemplate>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="pantry:PantryItem">
+                                    <SwipeView>
+                                        <SwipeView.LeftItems>
+                                            <SwipeItems Mode="Reveal">
+                                                <SwipeItem Text="Modifica"
+                                                           BackgroundColor="{StaticResource SecondaryContainer}"
+                                                           Command="{Binding BindingContext.EditItemCommand, Source={RelativeSource AncestorType={x:Type ContentPage}}}"
+                                                           CommandParameter="{Binding .}" />
+                                            </SwipeItems>
+                                        </SwipeView.LeftItems>
+                                        <SwipeView.RightItems>
+                                            <SwipeItems Mode="Reveal">
+                                                <SwipeItem Text="Elimina"
+                                                           BackgroundColor="{StaticResource ErrorContainer}"
+                                                           Command="{Binding BindingContext.DeleteItemCommand, Source={RelativeSource AncestorType={x:Type ContentPage}}}"
+                                                           CommandParameter="{Binding .}" />
+                                            </SwipeItems>
+                                        </SwipeView.RightItems>
+                                        <Border StrokeShape="RoundRectangle 16"
+                                                BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceContainer}, Dark={StaticResource DarkSurface}}"
+                                                Padding="16"
+                                                Margin="0,0,0,12">
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
+                                                <Border WidthRequest="48" HeightRequest="48"
+                                                        StrokeShape="RoundRectangle 12"
+                                                        BackgroundColor="{AppThemeBinding Light={StaticResource SecondaryContainer}, Dark={StaticResource DarkContainer}}"
+                                                        VerticalOptions="Center">
+                                                    <Label Text="{Binding QuantityDisplay}" HorizontalOptions="Center" VerticalOptions="Center" FontAttributes="Bold" />
+                                                </Border>
+                                                <VerticalStackLayout Spacing="4">
+                                                    <Label Text="{Binding Name}" Style="{StaticResource CardTitle}" />
+                                                    <Label Text="{Binding Brand}" Style="{StaticResource CardSubtitle}" />
+                                                    <Label Text="{Binding Category}" Style="{StaticResource CardSubtitle}" />
+                                                    <Label Text="{Binding ExpirationDate, StringFormat='Scadenza: {0:dd MMM yyyy}'}" />
+                                                </VerticalStackLayout>
+                                            </Grid>
+                                        </Border>
+                                    </SwipeView>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                            <CollectionView.EmptyView>
+                                <Border StrokeShape="RoundRectangle 18"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceContainer}, Dark={StaticResource DarkSurface}}"
+                                        Padding="20">
+                                    <VerticalStackLayout Spacing="6" HorizontalOptions="Center" WidthRequest="260">
+                                        <Label Text="La dispensa è vuota" HorizontalTextAlignment="Center" FontAttributes="Bold" />
+                                        <Label Text="Inizia una sessione di spesa per aggiungere prodotti." TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray300}}" HorizontalTextAlignment="Center" />
+                                    </VerticalStackLayout>
+                                </Border>
+                            </CollectionView.EmptyView>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </VerticalStackLayout>
+            </ScrollView>
+        </RefreshView>
     </Grid>
 </ContentPage>

--- a/Itemize/Pages/ShoppingSessionPage.xaml
+++ b/Itemize/Pages/ShoppingSessionPage.xaml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:pageModels="clr-namespace:Itemize.PageModels"
+             xmlns:pantry="clr-namespace:Itemize.Models.Pantry"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             x:Class="Itemize.Pages.ShoppingSessionPage"
+             x:DataType="pageModels:ShoppingSessionPageModel"
+             Title="Sessione spesa">
+
+    <ContentPage.Behaviors>
+        <toolkit:EventToCommandBehavior EventName="Appearing"
+                                        Command="{Binding AppearingCommand}" />
+    </ContentPage.Behaviors>
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <toolkit:InvertedBoolConverter x:Key="InvertedBoolConverter" />
+            <Style x:Key="SectionTitle" TargetType="Label">
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="FontAttributes" Value="Bold" />
+                <Setter Property="Margin" Value="0,20,0,10" />
+            </Style>
+            <Style x:Key="CardTitle" TargetType="Label">
+                <Setter Property="FontAttributes" Value="SemiBold" />
+                <Setter Property="FontSize" Value="16" />
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <Grid>
+        <ScrollView>
+            <VerticalStackLayout Spacing="20"
+                                  Padding="20">
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                    <VerticalStackLayout Spacing="4">
+                        <Label Text="Sessione di spesa"
+                               FontSize="28"
+                               FontAttributes="Bold" />
+                        <Label Text="Simula la scansione dei prodotti e conferma al termine"
+                               TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}" />
+                    </VerticalStackLayout>
+                    <Button Text="Nuova sessione"
+                            Command="{Binding StartNewSessionCommand}"
+                            HorizontalOptions="End"
+                            VerticalOptions="Center" />
+                </Grid>
+
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                    <VerticalStackLayout Spacing="4">
+                        <Label Text="Famiglia" FontAttributes="SemiBold" />
+                        <Picker ItemsSource="{Binding Families}"
+                                ItemDisplayBinding="{Binding Name}"
+                                SelectedItem="{Binding SelectedFamily}" />
+                    </VerticalStackLayout>
+                    <VerticalStackLayout Spacing="4"
+                                         HorizontalOptions="End"
+                                         VerticalOptions="Center">
+                        <Label Text="Totale stimato" FontAttributes="SemiBold" />
+                        <Label Text="{Binding EstimatedTotal, StringFormat='€ {0:F2}'}"
+                               FontSize="18"
+                               FontAttributes="Bold" />
+                    </VerticalStackLayout>
+                </Grid>
+
+                <Border IsVisible="{Binding HasActiveSession, Converter={StaticResource InvertedBoolConverter}}"
+                        StrokeShape="RoundRectangle 24"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceContainer}, Dark={StaticResource DarkSurface}}"
+                        Padding="24">
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="Nessuna sessione attiva" FontSize="20" FontAttributes="Bold" />
+                        <Label Text="Avvia una sessione per iniziare a scansionare i prodotti." />
+                        <Button Text="Inizia ora" Command="{Binding StartNewSessionCommand}" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <VerticalStackLayout IsVisible="{Binding HasActiveSession}" Spacing="20">
+                    <Border StrokeShape="RoundRectangle 24"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource PrimaryContainer}, Dark={StaticResource DarkContainer}}"
+                            Padding="20">
+                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" RowSpacing="8">
+                            <Label Grid.Row="0" Grid.Column="0"
+                                   Text="{Binding SessionTitle}"
+                                   FontSize="22"
+                                   FontAttributes="Bold" />
+                            <Label Grid.Row="1" Grid.Column="0"
+                                   Text="Prodotti in lista: {Binding Items.Count}"
+                                   TextColor="{AppThemeBinding Light={StaticResource Gray700}, Dark={StaticResource Gray300}}" />
+                            <Button Grid.Row="0" Grid.Column="1" Grid.RowSpan="2"
+                                    Text="Conferma"
+                                    Command="{Binding ConfirmSessionCommand}" />
+                        </Grid>
+                    </Border>
+
+                    <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+                        <Button Text="Scansiona prodotto"
+                                Command="{Binding ScanProductCommand}" />
+                        <Button Text="Inserisci manualmente"
+                                Command="{Binding ToggleManualEntryCommand}" />
+                    </Grid>
+
+                    <Border IsVisible="{Binding IsManualEntryVisible}"
+                            StrokeShape="RoundRectangle 18"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceContainer}, Dark={StaticResource DarkSurface}}"
+                            Padding="16">
+                        <VerticalStackLayout Spacing="10">
+                            <Label Text="Inserisci il codice a barre"
+                                   FontAttributes="Bold" />
+                            <Entry Placeholder="Es. 8001250120057"
+                                   Text="{Binding ManualBarcode}" />
+                            <Button Text="Aggiungi prodotto"
+                                    Command="{Binding AddManualProductCommand}" />
+                            <Label Text="Opzione di backup: usa solo in caso di problemi con la scansione"
+                                   Style="{StaticResource CardTitle}" />
+                        </VerticalStackLayout>
+                    </Border>
+
+                    <VerticalStackLayout>
+                        <Label Text="Prodotti aggiunti" Style="{StaticResource SectionTitle}" />
+                        <CollectionView ItemsSource="{Binding Items}"
+                                        SelectionMode="None">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="pantry:ShoppingItem">
+                                    <SwipeView>
+                                        <SwipeView.LeftItems>
+                                            <SwipeItems Mode="Reveal">
+                                                <SwipeItem Text="Modifica"
+                                                           BackgroundColor="{StaticResource SecondaryContainer}"
+                                                           Command="{Binding BindingContext.EditItemCommand, Source={RelativeSource AncestorType={x:Type ContentPage}}}"
+                                                           CommandParameter="{Binding .}" />
+                                            </SwipeItems>
+                                        </SwipeView.LeftItems>
+                                        <SwipeView.RightItems>
+                                            <SwipeItems Mode="Reveal">
+                                                <SwipeItem Text="Rimuovi"
+                                                           BackgroundColor="{StaticResource ErrorContainer}"
+                                                           Command="{Binding BindingContext.RemoveItemCommand, Source={RelativeSource AncestorType={x:Type ContentPage}}}"
+                                                           CommandParameter="{Binding .}" />
+                                            </SwipeItems>
+                                        </SwipeView.RightItems>
+                                        <Border StrokeShape="RoundRectangle 16"
+                                                BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceContainer}, Dark={StaticResource DarkSurface}}"
+                                                Padding="16"
+                                                Margin="0,0,0,12">
+                                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
+                                                <Border WidthRequest="48" HeightRequest="48"
+                                                        StrokeShape="RoundRectangle 12"
+                                                        BackgroundColor="{AppThemeBinding Light={StaticResource SecondaryContainer}, Dark={StaticResource DarkContainer}}"
+                                                        VerticalOptions="Center">
+                                                    <Label Text="{Binding QuantityDisplay}"
+                                                           HorizontalOptions="Center"
+                                                           VerticalOptions="Center"
+                                                           FontAttributes="Bold" />
+                                                </Border>
+                                                <VerticalStackLayout Spacing="4">
+                                                    <Label Text="{Binding Product.Name}" Style="{StaticResource CardTitle}" />
+                                                    <Label Text="{Binding Product.Brand}" />
+                                                    <Label Text="Unità: {Binding Unit}" />
+                                                    <Label Text="{Binding Price, StringFormat='€ {0:F2}'}"
+                                                           TextColor="{AppThemeBinding Light={StaticResource Gray700}, Dark={StaticResource Gray300}}" />
+                                                </VerticalStackLayout>
+                                            </Grid>
+                                        </Border>
+                                    </SwipeView>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                            <CollectionView.EmptyView>
+                                <Border StrokeShape="RoundRectangle 18"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceContainer}, Dark={StaticResource DarkSurface}}"
+                                        Padding="20">
+                                    <Label Text="Scansiona o aggiungi un prodotto per popolare la lista" />
+                                </Border>
+                            </CollectionView.EmptyView>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </VerticalStackLayout>
+            </VerticalStackLayout>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/Itemize/Pages/ShoppingSessionPage.xaml.cs
+++ b/Itemize/Pages/ShoppingSessionPage.xaml.cs
@@ -1,0 +1,12 @@
+using Itemize.PageModels;
+
+namespace Itemize.Pages;
+
+public partial class ShoppingSessionPage : ContentPage
+{
+    public ShoppingSessionPage(ShoppingSessionPageModel model)
+    {
+        InitializeComponent();
+        BindingContext = model;
+    }
+}

--- a/Itemize/Resources/Styles/AppStyles.xaml
+++ b/Itemize/Resources/Styles/AppStyles.xaml
@@ -50,7 +50,19 @@
         <OnIdiom.Desktop>15</OnIdiom.Desktop>
     </OnIdiom>
 
-    <FontImageSource x:Key="IconDashboard"
+        <FontImageSource x:Key="IconPantry"
+                     Glyph="{x:Static f:FluentUI.food_24_regular}"
+                     FontFamily="{x:Static f:FluentUI.FontFamily}"
+                     Color="{AppThemeBinding Light={StaticResource DarkOnLightBackground}, Dark={StaticResource LightOnDarkBackground}}"
+                     Size="{StaticResource IconSize}" />
+
+    <FontImageSource x:Key="IconShopping"
+                     Glyph="{x:Static f:FluentUI.shopping_bag_24_regular}"
+                     FontFamily="{x:Static f:FluentUI.FontFamily}"
+                     Color="{AppThemeBinding Light={StaticResource DarkOnLightBackground}, Dark={StaticResource LightOnDarkBackground}}"
+                     Size="{StaticResource IconSize}" />
+
+<FontImageSource x:Key="IconDashboard"
                      Glyph="{x:Static f:FluentUI.diagram_24_regular}"
                      FontFamily="{x:Static f:FluentUI.FontFamily}"
                      Color="{AppThemeBinding Light={StaticResource DarkOnLightBackground}, Dark={StaticResource LightOnDarkBackground}}"

--- a/Itemize/Services/FamilyContext.cs
+++ b/Itemize/Services/FamilyContext.cs
@@ -1,0 +1,14 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Itemize.Services;
+
+public class FamilyContext : ObservableObject
+{
+    private Guid? _selectedFamilyId;
+
+    public Guid? SelectedFamilyId
+    {
+        get => _selectedFamilyId;
+        set => SetProperty(ref _selectedFamilyId, value);
+    }
+}

--- a/Itemize/Services/Pantry/IPantryStore.cs
+++ b/Itemize/Services/Pantry/IPantryStore.cs
@@ -1,0 +1,30 @@
+using Itemize.Models.Pantry;
+
+namespace Itemize.Services.Pantry;
+
+public interface IPantryStore
+{
+    event EventHandler<PantryChangedEventArgs>? PantryChanged;
+
+    event EventHandler<ShoppingSessionChangedEventArgs>? ShoppingSessionChanged;
+
+    Task<IReadOnlyList<Family>> GetFamiliesAsync();
+
+    Task<Pantry> GetPantryAsync(Guid familyId);
+
+    Task DeletePantryItemAsync(Guid familyId, Guid pantryItemId);
+
+    Task UpdatePantryItemAsync(Guid familyId, PantryItem item);
+
+    Task<ShoppingSession?> GetCurrentSessionAsync(Guid familyId);
+
+    Task<ShoppingSession> StartSessionAsync(Guid familyId, string? title = null);
+
+    Task AddOrUpdateShoppingItemAsync(Guid sessionId, ShoppingItem item);
+
+    Task UpdateShoppingItemAsync(Guid sessionId, ShoppingItem item);
+
+    Task RemoveShoppingItemAsync(Guid sessionId, Guid shoppingItemId);
+
+    Task ConfirmSessionAsync(Guid sessionId, DateTime confirmationDate);
+}

--- a/Itemize/Services/Pantry/IProductCatalog.cs
+++ b/Itemize/Services/Pantry/IProductCatalog.cs
@@ -1,0 +1,10 @@
+using Itemize.Models.Pantry;
+
+namespace Itemize.Services.Pantry;
+
+public interface IProductCatalog
+{
+    Task<IReadOnlyList<Product>> GetProductsAsync();
+
+    Task<Product?> GetByBarcodeAsync(string barcode);
+}

--- a/Itemize/Services/Pantry/InMemoryPantryStore.cs
+++ b/Itemize/Services/Pantry/InMemoryPantryStore.cs
@@ -1,0 +1,515 @@
+using Microsoft.Maui.Graphics;
+
+using Itemize.Models.Pantry;
+
+namespace Itemize.Services.Pantry;
+
+public class InMemoryPantryStore : IPantryStore, IProductCatalog
+{
+    private readonly object _syncRoot = new();
+    private readonly List<User> _users = new();
+    private readonly List<Family> _families = new();
+    private readonly List<Product> _products = new();
+    private readonly List<ShoppingSession> _sessions = new();
+
+
+    public InMemoryPantryStore()
+    {
+        Seed();
+    }
+
+    public event EventHandler<PantryChangedEventArgs>? PantryChanged;
+
+    public event EventHandler<ShoppingSessionChangedEventArgs>? ShoppingSessionChanged;
+
+    public Task<IReadOnlyList<Family>> GetFamiliesAsync()
+    {
+        lock (_syncRoot)
+        {
+            return Task.FromResult<IReadOnlyList<Family>>(_families.Select(f => f.Clone()).ToList());
+        }
+    }
+
+    public Task<Pantry> GetPantryAsync(Guid familyId)
+    {
+        lock (_syncRoot)
+        {
+            var family = _families.First(f => f.Id == familyId);
+            return Task.FromResult(family.Pantry.Clone());
+        }
+    }
+
+    public Task DeletePantryItemAsync(Guid familyId, Guid pantryItemId)
+    {
+        lock (_syncRoot)
+        {
+            var family = _families.First(f => f.Id == familyId);
+            var removed = family.Pantry.Items.RemoveAll(i => i.Id == pantryItemId);
+            if (removed > 0)
+            {
+                PantryChanged?.Invoke(this, new PantryChangedEventArgs(familyId));
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task UpdatePantryItemAsync(Guid familyId, PantryItem item)
+    {
+        lock (_syncRoot)
+        {
+            var family = _families.First(f => f.Id == familyId);
+            var existing = family.Pantry.Items.FirstOrDefault(i => i.Id == item.Id);
+            if (existing is null)
+            {
+                family.Pantry.Items.Add(item.Clone());
+            }
+            else
+            {
+                existing.Quantity = item.Quantity;
+                existing.Unit = item.Unit;
+                existing.ExpirationDate = item.ExpirationDate;
+                existing.MinimumThreshold = item.MinimumThreshold;
+                existing.Notes = item.Notes;
+                existing.State = item.State;
+            }
+
+            PantryChanged?.Invoke(this, new PantryChangedEventArgs(familyId));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<ShoppingSession?> GetCurrentSessionAsync(Guid familyId)
+    {
+        lock (_syncRoot)
+        {
+            var session = _sessions
+                .Where(s => s.FamilyId == familyId && s.State == ShoppingSessionState.Active)
+                .OrderByDescending(s => s.StartedAt)
+                .FirstOrDefault();
+
+            return Task.FromResult(session?.Clone());
+        }
+    }
+
+    public Task<ShoppingSession> StartSessionAsync(Guid familyId, string? title = null)
+    {
+        ShoppingSession session;
+        lock (_syncRoot)
+        {
+            session = new ShoppingSession
+            {
+                FamilyId = familyId,
+                Title = title ?? $"Spesa del {DateTime.Now:dd MMMM}",
+                State = ShoppingSessionState.Active,
+                StartedAt = DateTime.Now,
+            };
+
+            _sessions.Add(session);
+        }
+
+        var cloned = session.Clone();
+        ShoppingSessionChanged?.Invoke(this, new ShoppingSessionChangedEventArgs(familyId, cloned));
+        return Task.FromResult(cloned);
+    }
+
+    public Task AddOrUpdateShoppingItemAsync(Guid sessionId, ShoppingItem item)
+    {
+        ShoppingSession session;
+        lock (_syncRoot)
+        {
+            session = _sessions.First(s => s.Id == sessionId);
+            var existing = session.Items.FirstOrDefault(i => i.ProductId == item.ProductId && !i.IsRemoved);
+            if (existing is null)
+            {
+                item.SessionId = sessionId;
+                session.Items.Add(item.Clone());
+            }
+            else
+            {
+                existing.Quantity += item.Quantity;
+                var additional = item.Price ?? 0m;
+                existing.Price = (existing.Price ?? 0m) + additional;
+                existing.AddedAt = DateTime.UtcNow;
+            }
+        }
+
+        RaiseSessionChanged(session);
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateShoppingItemAsync(Guid sessionId, ShoppingItem item)
+    {
+        ShoppingSession session;
+        lock (_syncRoot)
+        {
+            session = _sessions.First(s => s.Id == sessionId);
+            var existing = session.Items.First(i => i.Id == item.Id);
+            existing.Quantity = item.Quantity;
+            existing.Unit = item.Unit;
+            existing.Price = item.Price;
+        }
+
+        RaiseSessionChanged(session);
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveShoppingItemAsync(Guid sessionId, Guid shoppingItemId)
+    {
+        ShoppingSession session;
+        lock (_syncRoot)
+        {
+            session = _sessions.First(s => s.Id == sessionId);
+            var existing = session.Items.FirstOrDefault(i => i.Id == shoppingItemId);
+            if (existing is not null)
+            {
+                existing.IsRemoved = true;
+            }
+        }
+
+        RaiseSessionChanged(session);
+        return Task.CompletedTask;
+    }
+
+    public Task ConfirmSessionAsync(Guid sessionId, DateTime confirmationDate)
+    {
+        ShoppingSession session;
+        Family family;
+        lock (_syncRoot)
+        {
+            session = _sessions.First(s => s.Id == sessionId);
+            family = _families.First(f => f.Id == session.FamilyId);
+
+            if (session.State != ShoppingSessionState.Active)
+            {
+                return Task.CompletedTask;
+            }
+
+            session.State = ShoppingSessionState.Completed;
+            session.ConfirmedAt = confirmationDate;
+
+            foreach (var item in session.Items.Where(i => !i.IsRemoved))
+            {
+                var pantryItem = family.Pantry.Items.FirstOrDefault(i => i.ProductId == item.ProductId);
+                if (pantryItem is null)
+                {
+                    pantryItem = new PantryItem
+                    {
+                        PantryId = family.Pantry.Id,
+                        ProductId = item.ProductId,
+                        Name = item.Product.Name,
+                        Brand = item.Product.Brand,
+                        Category = item.Product.Category,
+                        Quantity = item.Quantity,
+                        Unit = item.Unit,
+                        AddedAt = confirmationDate,
+                        MinimumThreshold = 1,
+                    };
+
+                    family.Pantry.Items.Add(pantryItem);
+                }
+                else
+                {
+                    pantryItem.Quantity += item.Quantity;
+                    pantryItem.AddedAt = confirmationDate;
+                }
+            }
+        }
+
+        PantryChanged?.Invoke(this, new PantryChangedEventArgs(family.Id));
+        RaiseSessionChanged(session);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<Product>> GetProductsAsync()
+    {
+        lock (_syncRoot)
+        {
+            return Task.FromResult<IReadOnlyList<Product>>(_products.Select(p => p.Clone()).ToList());
+        }
+    }
+
+    public Task<Product?> GetByBarcodeAsync(string barcode)
+    {
+        lock (_syncRoot)
+        {
+            var product = _products.FirstOrDefault(p => string.Equals(p.Barcode, barcode, StringComparison.OrdinalIgnoreCase));
+            return Task.FromResult(product?.Clone());
+        }
+    }
+
+    private void RaiseSessionChanged(ShoppingSession session)
+    {
+        ShoppingSessionChanged?.Invoke(this, new ShoppingSessionChangedEventArgs(session.FamilyId, session.Clone()));
+    }
+
+    private void Seed()
+    {
+        var userAlice = new User { DisplayName = "Alice", Email = "alice@example.com" };
+        var userMarco = new User { DisplayName = "Marco", Email = "marco@example.com" };
+        var userSofia = new User { DisplayName = "Sofia", Email = "sofia@example.com" };
+
+        _users.AddRange(new[] { userAlice, userMarco, userSofia });
+
+        var pasta = new Product
+        {
+            Name = "Spaghetti n.5",
+            Brand = "De Cecco",
+            Category = "Pasta",
+            Barcode = "8001250120057",
+            DefaultUnit = QuantityUnit.Pack,
+            DefaultQuantity = 1,
+            AveragePrice = 1.69m,
+        };
+
+        var tomatoSauce = new Product
+        {
+            Name = "Passata di Pomodoro",
+            Brand = "Mutti",
+            Category = "Salse",
+            Barcode = "8005121001008",
+            DefaultUnit = QuantityUnit.Bottle,
+            DefaultQuantity = 1,
+            AveragePrice = 1.39m,
+        };
+
+        var tuna = new Product
+        {
+            Name = "Tonno all'olio di oliva",
+            Brand = "Rio Mare",
+            Category = "Dispensa",
+            Barcode = "8004030000035",
+            DefaultUnit = QuantityUnit.Can,
+            DefaultQuantity = 1,
+            AveragePrice = 1.99m,
+        };
+
+        var milk = new Product
+        {
+            Name = "Latte fresco intero",
+            Brand = "Parmalat",
+            Category = "Freschi",
+            Barcode = "8002200150026",
+            DefaultUnit = QuantityUnit.Liter,
+            DefaultQuantity = 1,
+            AveragePrice = 1.45m,
+        };
+
+        var yogurt = new Product
+        {
+            Name = "Yogurt bianco",
+            Brand = "Fage",
+            Category = "Freschi",
+            Barcode = "5213000114535",
+            DefaultUnit = QuantityUnit.Pack,
+            DefaultQuantity = 1,
+            AveragePrice = 0.99m,
+        };
+
+        var rice = new Product
+        {
+            Name = "Riso Carnaroli",
+            Brand = "Scotti",
+            Category = "Dispensa",
+            Barcode = "8001860001050",
+            DefaultUnit = QuantityUnit.Pack,
+            DefaultQuantity = 1,
+            AveragePrice = 2.29m,
+        };
+
+        var eggs = new Product
+        {
+            Name = "Uova bio",
+            Brand = "Fattoria",
+            Category = "Freschi",
+            Barcode = "8059300022334",
+            DefaultUnit = QuantityUnit.Pack,
+            DefaultQuantity = 1,
+            AveragePrice = 2.89m,
+        };
+
+        var bread = new Product
+        {
+            Name = "Pane integrale",
+            Brand = "Panificio Napoli",
+            Category = "Forno",
+            Barcode = "200000000001",
+            DefaultUnit = QuantityUnit.Pack,
+            DefaultQuantity = 1,
+            AveragePrice = 2.5m,
+        };
+
+        var salad = new Product
+        {
+            Name = "Insalata mista",
+            Brand = "OrtoVivo",
+            Category = "Ortaggi",
+            Barcode = "200000000002",
+            DefaultUnit = QuantityUnit.Pack,
+            DefaultQuantity = 1,
+            AveragePrice = 1.2m,
+        };
+
+        var beans = new Product
+        {
+            Name = "Fagioli cannellini",
+            Brand = "Cirio",
+            Category = "Dispensa",
+            Barcode = "8004900002330",
+            DefaultUnit = QuantityUnit.Can,
+            DefaultQuantity = 1,
+            AveragePrice = 1.1m,
+        };
+
+        _products.AddRange(new[]
+        {
+            pasta, tomatoSauce, tuna, milk, yogurt, rice, eggs, bread, salad, beans
+        });
+
+        var familyId = Guid.NewGuid();
+        var family = new Family
+        {
+            Id = familyId,
+            Name = "Famiglia Rossi",
+            AccentColor = Color.FromArgb("#FF7B54"),
+            Pantry = new Pantry
+            {
+                Id = Guid.NewGuid(),
+                FamilyId = familyId,
+                Items = new List<PantryItem>
+                {
+                    new()
+                    {
+                        PantryId = family.Pantry.Id,
+                        ProductId = pasta.Id,
+                        Name = pasta.Name,
+                        Brand = pasta.Brand,
+                        Category = pasta.Category,
+                        Quantity = 3,
+                        Unit = QuantityUnit.Pack,
+                        MinimumThreshold = 1,
+                        ExpirationDate = DateTime.Today.AddMonths(10),
+                        AddedAt = DateTime.Today.AddDays(-12),
+                    },
+                    new()
+                    {
+                        PantryId = family.Pantry.Id,
+                        ProductId = tomatoSauce.Id,
+                        Name = tomatoSauce.Name,
+                        Brand = tomatoSauce.Brand,
+                        Category = tomatoSauce.Category,
+                        Quantity = 2,
+                        Unit = QuantityUnit.Bottle,
+                        MinimumThreshold = 1,
+                        ExpirationDate = DateTime.Today.AddMonths(8),
+                        AddedAt = DateTime.Today.AddDays(-6),
+                    },
+                    new()
+                    {
+                        PantryId = family.Pantry.Id,
+                        ProductId = milk.Id,
+                        Name = milk.Name,
+                        Brand = milk.Brand,
+                        Category = milk.Category,
+                        Quantity = 1,
+                        Unit = QuantityUnit.Liter,
+                        MinimumThreshold = 1,
+                        ExpirationDate = DateTime.Today.AddDays(2),
+                        AddedAt = DateTime.Today.AddDays(-1),
+                    },
+                    new()
+                    {
+                        PantryId = family.Pantry.Id,
+                        ProductId = yogurt.Id,
+                        Name = yogurt.Name,
+                        Brand = yogurt.Brand,
+                        Category = yogurt.Category,
+                        Quantity = 4,
+                        Unit = QuantityUnit.Pack,
+                        MinimumThreshold = 2,
+                        ExpirationDate = DateTime.Today.AddDays(4),
+                        AddedAt = DateTime.Today.AddDays(-2),
+                    },
+                    new()
+                    {
+                        PantryId = family.Pantry.Id,
+                        ProductId = tuna.Id,
+                        Name = tuna.Name,
+                        Brand = tuna.Brand,
+                        Category = tuna.Category,
+                        Quantity = 5,
+                        Unit = QuantityUnit.Can,
+                        MinimumThreshold = 2,
+                        ExpirationDate = DateTime.Today.AddMonths(18),
+                        AddedAt = DateTime.Today.AddDays(-40),
+                    },
+                    new()
+                    {
+                        PantryId = family.Pantry.Id,
+                        ProductId = rice.Id,
+                        Name = rice.Name,
+                        Brand = rice.Brand,
+                        Category = rice.Category,
+                        Quantity = 1,
+                        Unit = QuantityUnit.Pack,
+                        MinimumThreshold = 1,
+                        ExpirationDate = DateTime.Today.AddMonths(12),
+                        AddedAt = DateTime.Today.AddDays(-15),
+                    },
+                    new()
+                    {
+                        PantryId = family.Pantry.Id,
+                        ProductId = eggs.Id,
+                        Name = eggs.Name,
+                        Brand = eggs.Brand,
+                        Category = eggs.Category,
+                        Quantity = 1,
+                        Unit = QuantityUnit.Pack,
+                        MinimumThreshold = 1,
+                        ExpirationDate = DateTime.Today.AddDays(1),
+                        AddedAt = DateTime.Today.AddDays(-3),
+                    },
+                    new()
+                    {
+                        PantryId = family.Pantry.Id,
+                        ProductId = bread.Id,
+                        Name = bread.Name,
+                        Brand = bread.Brand,
+                        Category = bread.Category,
+                        Quantity = 1,
+                        Unit = QuantityUnit.Pack,
+                        MinimumThreshold = 1,
+                        ExpirationDate = DateTime.Today.AddDays(1),
+                        AddedAt = DateTime.Today.AddDays(-1),
+                    },
+                    new()
+                    {
+                        PantryId = family.Pantry.Id,
+                        ProductId = beans.Id,
+                        Name = beans.Name,
+                        Brand = beans.Brand,
+                        Category = beans.Category,
+                        Quantity = 2,
+                        Unit = QuantityUnit.Can,
+                        MinimumThreshold = 1,
+                        ExpirationDate = DateTime.Today.AddMonths(14),
+                        AddedAt = DateTime.Today.AddDays(-20),
+                    },
+                }
+            },
+            Members = new List<FamilyMembership>
+            {
+                new() { UserId = userAlice.Id, Role = FamilyRole.Owner },
+                new() { UserId = userMarco.Id, Role = FamilyRole.Member },
+                new() { UserId = userSofia.Id, Role = FamilyRole.Member },
+            },
+        };
+
+        userAlice.FamilyIds.Add(familyId);
+        userMarco.FamilyIds.Add(familyId);
+        userSofia.FamilyIds.Add(familyId);
+
+        _families.Add(family);
+    }
+}

--- a/Itemize/Services/Pantry/PantryChangedEventArgs.cs
+++ b/Itemize/Services/Pantry/PantryChangedEventArgs.cs
@@ -1,0 +1,11 @@
+namespace Itemize.Services.Pantry;
+
+public class PantryChangedEventArgs : EventArgs
+{
+    public PantryChangedEventArgs(Guid familyId)
+    {
+        FamilyId = familyId;
+    }
+
+    public Guid FamilyId { get; }
+}

--- a/Itemize/Services/Pantry/ShoppingSessionChangedEventArgs.cs
+++ b/Itemize/Services/Pantry/ShoppingSessionChangedEventArgs.cs
@@ -1,0 +1,16 @@
+using Itemize.Models.Pantry;
+
+namespace Itemize.Services.Pantry;
+
+public class ShoppingSessionChangedEventArgs : EventArgs
+{
+    public ShoppingSessionChangedEventArgs(Guid familyId, ShoppingSession session)
+    {
+        FamilyId = familyId;
+        Session = session;
+    }
+
+    public Guid FamilyId { get; }
+
+    public ShoppingSession Session { get; }
+}

--- a/Itemize/Services/RecipeSuggestionService.cs
+++ b/Itemize/Services/RecipeSuggestionService.cs
@@ -1,0 +1,66 @@
+using Itemize.Models.Pantry;
+
+namespace Itemize.Services;
+
+public class RecipeSuggestionService
+{
+    private static readonly string[] PastaKeywords = ["pasta", "spaghetti", "penne"];
+    private static readonly string[] TomatoKeywords = ["pomodoro", "passata", "salsa"];
+    private static readonly string[] RiceKeywords = ["riso"];
+    private static readonly string[] TunaKeywords = ["tonno"];
+    private static readonly string[] EggKeywords = ["uova"];
+
+    public IReadOnlyList<RecipeSuggestion> BuildSuggestions(IEnumerable<PantryItem> pantryItems)
+    {
+        var items = pantryItems.Where(i => i.State == PantryItemState.Active).ToList();
+        var suggestions = new List<RecipeSuggestion>();
+
+        if (HasAll(items, PastaKeywords) && HasAll(items, TomatoKeywords))
+        {
+            suggestions.Add(new RecipeSuggestion
+            {
+                Title = "Spaghetti al pomodoro",
+                Description = "Pasta veloce con salsa di pomodoro e basilico fresco.",
+                Ingredients = new[] { "Spaghetti", "Passata di pomodoro", "Olio", "Basilico" },
+            });
+        }
+
+        if (HasAll(items, RiceKeywords) && HasAll(items, TunaKeywords))
+        {
+            suggestions.Add(new RecipeSuggestion
+            {
+                Title = "Insalata di riso mediterranea",
+                Description = "Riso freddo con tonno, verdure croccanti e mais.",
+                Ingredients = new[] { "Riso", "Tonno", "Mais", "Olive" },
+            });
+        }
+
+        if (HasAll(items, EggKeywords) && HasAll(items, TomatoKeywords))
+        {
+            suggestions.Add(new RecipeSuggestion
+            {
+                Title = "Shakshuka veloce",
+                Description = "Uova in umido con salsa di pomodoro e paprika.",
+                Ingredients = new[] { "Uova", "Passata di pomodoro", "Cipolla", "Paprika" },
+            });
+        }
+
+        if (!suggestions.Any())
+        {
+            suggestions.Add(new RecipeSuggestion
+            {
+                Title = "Idea rapida",
+                Description = "Controlla cosa sta per scadere e crea una ricetta zero sprechi!",
+                Ingredients = Array.Empty<string>(),
+            });
+        }
+
+        return suggestions;
+    }
+
+    private static bool HasAll(IEnumerable<PantryItem> items, IEnumerable<string> keywords)
+    {
+        return keywords.All(keyword =>
+            items.Any(item => item.Name.Contains(keyword, StringComparison.OrdinalIgnoreCase)));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce pantry, product, family, and shopping session domain models with an in-memory store and recipe suggestions
- redesign the main page as a pantry dashboard with expiring items, low stock highlights, and grouped inventory
- add a shopping session page to simulate scanning, manage cart items, and confirm purchases into the pantry

## Testing
- `dotnet build Itemize/Itemize.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cae6ff0784833097d5a2ee14349f83